### PR TITLE
Change OTP Period to 60 seconds (part 2) [Fixes #8]

### DIFF
--- a/scripts/totptest.py
+++ b/scripts/totptest.py
@@ -12,7 +12,7 @@ def generate(seed=None, time=None):
         except Exception as e:
             raise Exception('Error while reading seed file, make sure to execute the request.py script before this') from e
 
-    gen = pyotp.TOTP(seed, digits=8, digest=hashlib.sha256)
+    gen = pyotp.TOTP(seed, digits=8, digest=hashlib.sha256, interval=60)
     code = 0
     if time is None:
         code = gen.now()


### PR DESCRIPTION
L'ultimo commit risolveva solo in parte il bug #8 .

In particolare la durata del codice OTP veniva usato in diverse parti nel codice

| File | Commit 6b765fe40a2dc23373a0209b6b61117bd7b6afa6 | Questo PR |
| --- | --- | --- |
| `genqr.py` | OK | OK |
| `requests.py` | OK | OK |
| `totptest.py` | not fixed | OK |