### PR TITLE
Change 60 seconds config in script to get back to 30 seconds

### DIFF
--- a/scripts/genqr.py
+++ b/scripts/genqr.py
@@ -16,7 +16,7 @@ def generate_and_print(seed=None):
 		'secret': seed,
 		'algo': 'SHA256',
 		'digits': 8,
-		'period': 60
+		'period': 30
 	}
 
 	print('In case the qr code won\'t show up, use a qr generator to convert this uri:')

--- a/scripts/request.py
+++ b/scripts/request.py
@@ -33,7 +33,7 @@ def extract_otp(activation_code):
 		'applicationcode': app_code,
 		'activationcode': CBCUtil.encrypt(encryption_key, activation_code),
 		'authtoken': CBCUtil.encrypt(encryption_key, str(int(time.time() * 1000))),
-		'otp1': pyotp.TOTP(base64.b32encode(base64.b16decode(seed)), digits=8, digest=hashlib.sha256, interval=60).now(),
+		'otp1': pyotp.TOTP(base64.b32encode(base64.b16decode(seed)), digits=8, digest=hashlib.sha256, interval=30).now(),
 		'otp2': ''
 	}
 	req2 = requests.post('https://mobile.strongauth.it/MobileLicenceServer/webresources/MobileLicenceService/SeedValidate', json=payload, headers=user_agent)

--- a/scripts/totptest.py
+++ b/scripts/totptest.py
@@ -12,7 +12,7 @@ def generate(seed=None, time=None):
         except Exception as e:
             raise Exception('Error while reading seed file, make sure to execute the request.py script before this') from e
 
-    gen = pyotp.TOTP(seed, digits=8, digest=hashlib.sha256, interval=60)
+    gen = pyotp.TOTP(seed, digits=8, digest=hashlib.sha256, interval=30)
     code = 0
     if time is None:
         code = gen.now()


### PR DESCRIPTION
I've noticed that the script currently doesn't work and commented in issue #8. Checking the app, I noticed the OPT only work 30 seconds, so I reverted the  changes from 60 to 30 seconds, and I was able to fetch the seed.