### PR TITLE
Fix first QR code

### DIFF
--- a/scripts/genqr.py
+++ b/scripts/genqr.py
@@ -7,9 +7,10 @@ def generate_and_print(seed=None, otp_type='TOTP', digits=8, period=60, counter=
 		try:
 			with open(os.path.join(os.sys.path[0], 'seed.json'), 'r') as f:
 				seed, otp_type, digits, period, counter = json.loads(f.read())
-				period = period/1000
 		except Exception as e:
 			raise Exception('Error while reading seed file, make sure to execute the request.py script before this') from e
+	
+	period = int(period/1000)
 	
 	uri = 'otpauth://%(type)s/%(issuer)s:%(user)s?secret=%(secret)s&issuer=%(issuer)s&algorithm=%(algo)s&digits=%(digits)d&period=%(period)d' % {
 		'type': otp_type.lower(),


### PR DESCRIPTION
The function is called in main.py with all the arguments, but the period is divided only if we use the defaults.

Fix #17.